### PR TITLE
Fixing incorrect API endpoint for body measurement

### DIFF
--- a/whoopy/handlers/handler_v1.py
+++ b/whoopy/handlers/handler_v1.py
@@ -54,7 +54,7 @@ class WhoopUserHandler(WhoopHandler):
         return models.UserProfile(**data)
 
     def body_measurements(self) -> models.UserMeasurements:
-        res = self._get("user/body_measurements")
+        res = self._get("user/measurement/body")
         data = self._verify(res)
 
         return models.UserMeasurements(**data)


### PR DESCRIPTION
Method body_measurements didn't work for me, so I fixed it. 

According to https://developer.whoop.com/api/#tag/User/operation/getBodyMeasurement the correct endpoint is "user/measurement/body"