### PR TITLE
Recovery fix

### DIFF
--- a/tests/test_handlers_v2.py
+++ b/tests/test_handlers_v2.py
@@ -271,7 +271,7 @@ class TestRecoveryHandler:
                 }
 
                 m.get(
-                    "https://api.prod.whoop.com/developer/v2/activity/recovery/cycle/12345/recovery",
+                    "https://api.prod.whoop.com/developer/v2/cycle/12345/recovery",
                     payload=recovery_data,
                 )
 

--- a/whoopy/handlers/handlers_v2.py
+++ b/whoopy/handlers/handlers_v2.py
@@ -119,7 +119,7 @@ class RecoveryHandler(CollectionHandler[models.Recovery]):
         """
         super().__init__(
             client=client,
-            collection_path="activity/recovery",
+            collection_path="recovery",
             model_class=models.Recovery,
             response_class=models.RecoveryCollection,  # type: ignore[arg-type]
         )
@@ -138,7 +138,7 @@ class RecoveryHandler(CollectionHandler[models.Recovery]):
             ResourceNotFoundError: If recovery not found
         """
         try:
-            data = await self._get(f"activity/recovery/cycle/{cycle_id}/recovery")
+            data = await self._get(f"cycle/{cycle_id}/recovery")
             return models.Recovery(**data)
         except Exception as e:
             if "404" in str(e):


### PR DESCRIPTION
Hi,

I noticed it was not possible to use the get_all() function for the RecoveryHandler, until I noticed that in the official Whoop Api Docs for v2 the routes are different. I have updated the tests as well and tested it locally.

More detailed:
`client.recovery.get_all(max_records=1)` returned: `{"detail": "Resource not found"}`

Link to the API Docs: https://developer.whoop.com/api#tag/Recovery

BR
Andreas